### PR TITLE
Provides better support for Compose configuration

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,11 @@ function terminate() {
     kill $pids 2>/dev/null
 }
 
+# set clamd values according to user params. set default using parameter expansion if unset or null
+sed -i -e 's/^MaxFileSize 25M$/MaxFileSize '${CLAMAV_MAX_FILE_SIZE:-25}'M/' '/etc/clamav/clamd.conf'
+sed -i -e 's/^MaxScanSize 100M$/MaxScanSize '${CLAMAV_MAX_SCAN_SIZE:-100}'M/' '/etc/clamav/clamd.conf'
+sed -i -e 's/^StreamMaxLength 25M$/StreamMaxLength '${CLAMAV_MAX_STREAM_LENGTH:-100}'M/' '/etc/clamav/clamd.conf'
+
 trap terminate CHLD
 wait
 


### PR DESCRIPTION
* `MaxFileSize` and `MaxScanSize` set to Artefactual defaults if not configured. 
* `StreamMaxLength` upped to ease symptoms caused by trying to stream files larger than existing limit.

Tested using alternative fork on Docker Hub, https://hub.docker.com/r/rossspencer/docker-clamavd/
Eases the symptoms exhibited in, artefactual/archivematica#779 

Closes #3 